### PR TITLE
Feature/api access object

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,231 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="AddOperatorModifier" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="AddVarianceModifier" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="AmbiguousNonLocalJump" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ArrayInDataClass" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="BooleanLiteralArgument" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="CanBeParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CanBePrimaryConstructorProperty" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CanBeVal" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CanSealedSubClassBeObject" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="CascadeIf" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ClassName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ComplexRedundantLet" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConflictingExtensionProperty" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConstPropertyName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConstantConditionIf" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ControlFlowWithEmptyBody" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConvertArgumentToSet" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConvertCallChainIntoSequence" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConvertLambdaToReference" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ConvertNaNEquality" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConvertObjectToDataObject" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConvertPairConstructorToToFunction" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ConvertReferenceToLambda" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ConvertSecondaryConstructorToPrimary" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConvertToStringTemplate" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConvertTryFinallyToUseCall" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConvertTwoComparisonsToRangeCheck" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="CopyWithoutNamedArguments" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="DataClassPrivateConstructor" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DeferredResultUnused" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DelegationToVarProperty" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DeprecatedCallableAddReplaceWith" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="DeprecatedGradleDependency" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DeprecatedMavenDependency" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DestructuringWrongName" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DifferentKotlinGradleVersion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DifferentKotlinMavenVersion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DifferentMavenStdlibVersion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DifferentStdlibGradleVersion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EmptyRange" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EnumEntryName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="EnumValuesSoftDeprecate" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EnumValuesSoftDeprecateInJava" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EqualsOrHashCode" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ExplicitThis" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="FakeJvmFieldConstant" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FloatingPointLiteralPrecision" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="FoldInitializerAndIfToElvis" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ForEachParameterNotUsed" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="FunctionName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="FunctionWithLambdaExpressionBody" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="HasPlatformType" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="IfThenToElvis" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="IfThenToSafeAccess" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="IllegalIdentifier" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="ImplicitNullableNothingType" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ImplicitThis" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="InconsistentCommentForJavaParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IntroduceWhenSubject" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaCollectionsStaticMethod" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaCollectionsStaticMethodOnImmutableList" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaIoSerializableObjectMustHaveReadResolve" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaMapForEach" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="JoinDeclarationAndAssignment" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="KDocUnresolvedReference" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinCatchMayIgnoreException" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinConstantConditions" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinCovariantEquals" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinDeprecation" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinDoubleNegation" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinEqualsBetweenInconvertibleTypes" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinInternalInJava" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="KotlinInvalidBundleOrProperty" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="KotlinJvmAnnotationInJava" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinMavenPluginPhase" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinRedundantDiagnosticSuppress" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinRedundantOverride" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinSealedInheritorsInJava" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="KotlinTestJUnit" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinThrowableNotThrown" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinUnusedImport" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LateinitVarOverridesLateinitVar" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LeakingThis" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LiftReturnOrAssignment" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LocalVariableName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="LoopToCallChain" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="MainFunctionReturnUnit" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MapGetWithNotNullAssertionOperator" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="MayBeConstant" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="MemberVisibilityCanBePrivate" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="MigrateDiagnosticSuppression" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MoveLambdaOutsideParentheses" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="MoveVariableDeclarationIntoWhen" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="NestedLambdaShadowedImplicitParameter" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="NonExternalClassifierExtendingStateOrProps" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NonVarPropertyInExternalInterface" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NullChecksToSafeCall" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NullableBooleanElvis" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ObjectLiteralToLambda" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ObjectPrivatePropertyName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ObjectPropertyName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="OptionalExpectation" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="PackageDirectoryMismatch" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PackageName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PlatformExtensionReceiverOfInline" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PrivatePropertyName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PropertyName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ProtectedInFinal" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RecursiveEqualsCall" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RecursivePropertyAccessor" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantAsSequence" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantCompanionReference" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantConstructorKeyword" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantElseInIf" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="RedundantElvisReturnNull" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantEmptyInitializerBlock" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantEnumConstructorInvocation" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantExplicitType" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantGetter" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantIf" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantLambdaArrow" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantLambdaOrAnonymousFunction" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantModalityModifier" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantNullableReturnType" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantObjectTypeCheck" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="RedundantRequireNotNullCall" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantReturnLabel" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantRunCatching" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantSamConstructor" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantSemicolon" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantSetter" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantSuspendModifier" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantUnitExpression" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantUnitReturnType" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantVisibilityModifier" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantWith" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveCurlyBracesFromTemplate" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveEmptyClassBody" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveEmptyParenthesesFromAnnotationEntry" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveEmptyParenthesesFromLambdaCall" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveEmptyPrimaryConstructor" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveEmptySecondaryConstructorBody" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveExplicitSuperQualifier" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveExplicitTypeArguments" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveForLoopIndices" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveRedundantBackticks" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveRedundantCallsOfConversionMethods" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveRedundantQualifierName" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveRedundantSpreadOperator" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveSetterParameterType" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveSingleExpressionStringTemplate" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveToStringInStringTemplate" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceArrayEqualityOpWithArraysEquals" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceArrayOfWithLiteral" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceAssertBooleanWithAssertEquality" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceAssociateFunction" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceCallWithBinaryOperator" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceGetOrSet" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceGuardClauseWithFunctionCall" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceIsEmptyWithIfEmpty" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceJavaStaticMethodWithKotlinAnalog" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceManualRangeWithIndicesCalls" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceMapIndexedWithListGenerator" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceNegatedIsEmptyWithIsNotEmpty" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplacePutWithAssignment" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceRangeStartEndInclusiveWithFirstLast" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceRangeToWithRangeUntil" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceRangeToWithUntil" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceReadLineWithReadln" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceSizeCheckWithIsNotEmpty" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceSizeZeroCheckWithIsEmpty" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceStringFormatWithLiteral" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceSubstringWithDropLast" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceSubstringWithIndexingOperation" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceSubstringWithSubstringAfter" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceSubstringWithSubstringBefore" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceSubstringWithTake" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceToStringWithStringTemplate" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceToWithInfixForm" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceUntilWithRangeUntil" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceWithEnumMap" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceWithIgnoreCaseEquals" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceWithImportAlias" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceWithOperatorAssignment" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceWithStringBuilderAppendRange" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SafeCastWithReturn" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScopeFunctionConversion" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="SelfAssignment" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SelfReferenceConstructorParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SetterBackingFieldAssignment" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimpleRedundantLet" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifiableCall" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifiableCallChain" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifyAssertNotNull" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="SimplifyBooleanWithConstants" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifyNegatedBinaryExpression" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifyNestedEachInScopeFunction" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifyWhenWithBooleanConstantCondition" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SortModifiers" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SuspendFunctionOnCoroutineScope" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SuspiciousAsDynamic" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SuspiciousCallableReferenceInLambda" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SuspiciousCollectionReassignment" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SuspiciousEqualsCombination" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SuspiciousVarProperty" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TestFunctionName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="TrailingComma" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="TypeParameterFindViewById" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnclearPrecedenceOfBinaryExpression" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnlabeledReturnInsideLambda" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryOptInAnnotation" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryVariable" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnsafeCastFromDynamic" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedDataClassCopyResult" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedEquals" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedLambdaExpressionBody" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedReceiverParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedSymbol" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedUnaryOperator" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UseExpressionBody" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="UsePropertyAccessSyntax" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="UseWithIndex" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="UselessCallOnCollection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UselessCallOnNotNull" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="VerboseNullabilityAndEmptiness" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="WrapUnaryOperator" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,17 @@
             <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20231013</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/data_access/ApiAccessObject.java
+++ b/src/main/java/data_access/ApiAccessObject.java
@@ -34,7 +34,7 @@ public class ApiAccessObject {
     }
 
     /**
-     * Get the ETA from a start to an end location in hours
+     * Get the ETA from a start to an end location in minutes
      *
      * @param start The start location
      * @param end The end location
@@ -43,8 +43,8 @@ public class ApiAccessObject {
      */
     public float getEta(String start, String end) throws InvalidLocationException, ApiAccessException {
         List<String> fields = new ArrayList<>();
-        fields.add("eta");
-        return requestRoutingData(start, end, fields).get("eta");
+        fields.add("time");
+        return requestRoutingData(start, end, fields).get("time") / 60;
     }
 
     /**
@@ -57,10 +57,10 @@ public class ApiAccessObject {
      */
     public float getPrice(String start, String end) throws InvalidLocationException, ApiAccessException {
         List<String> fields = new ArrayList<>();
-        fields.add("eta");
+        fields.add("time");
         fields.add("distance");
         Map<String, Float> routingData = requestRoutingData(start, end, fields);
-        return routingData.get("distance") * 0.1f + routingData.get("eta") * 20;
+        return routingData.get("distance") * 0.05f + routingData.get("time") * 0.002f;
     }
 
     /**
@@ -90,10 +90,8 @@ public class ApiAccessObject {
         try {
             // execute and print API response
             Response response = client.newCall(request).execute();
-            System.out.println("Response : " + response);
             if (response.code() == 200) {
-                JSONObject responseBody = new JSONObject(response.body().string());
-                return responseBody.getString("url");
+                return request.url().toString();
             } else {
                 throw new InvalidLocationException("Invalid location");
             }

--- a/src/main/java/data_access/ApiAccessObject.java
+++ b/src/main/java/data_access/ApiAccessObject.java
@@ -93,10 +93,10 @@ public class ApiAccessObject {
             if (response.code() == 200) {
                 return request.url().toString();
             } else {
-                throw new InvalidLocationException("Invalid location");
+                throw new ApiAccessException();
             }
         } catch (IOException | JSONException e) {
-            throw new ApiAccessException();
+            throw new InvalidLocationException("Invalid location");
         }
     }
 
@@ -140,10 +140,10 @@ public class ApiAccessObject {
 
                 return distanceEtaMap;
             } else {
-                throw new InvalidLocationException("Invalid location");
+                throw new ApiAccessException();
             }
         } catch (IOException | JSONException e) {
-            throw new ApiAccessException();
+            throw new InvalidLocationException("Invalid location");
         }
     }
 }

--- a/src/main/java/data_access/ApiAccessObject.java
+++ b/src/main/java/data_access/ApiAccessObject.java
@@ -3,6 +3,7 @@ import okhttp3.*;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import use_case.CreateRequest.ApiAccessException;
 import use_case.CreateRequest.InvalidLocationException;
 
 import java.io.IOException;
@@ -12,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ApiAccessObject {
-    private String apiKey;
+    private final String apiKey;
 
     public ApiAccessObject(String apiKey) {
         this.apiKey = apiKey;
@@ -26,7 +27,7 @@ public class ApiAccessObject {
      * @return The distance from start to end
      * @throws InvalidLocationException One of the inputted locations has invalid
      */
-    public float getDistance(String start, String end) throws InvalidLocationException {
+    public float getDistance(String start, String end) throws InvalidLocationException, ApiAccessException {
         List<String> fields = new ArrayList<>();
         fields.add("distance");
         return requestRoutingData(start, end, fields).get("distance") / 10;
@@ -40,7 +41,7 @@ public class ApiAccessObject {
      * @return The ETA from start to end
      * @throws InvalidLocationException One of the inputted locations has invalid
      */
-    public float getEta(String start, String end) throws InvalidLocationException {
+    public float getEta(String start, String end) throws InvalidLocationException, ApiAccessException {
         List<String> fields = new ArrayList<>();
         fields.add("eta");
         return requestRoutingData(start, end, fields).get("eta");
@@ -54,7 +55,7 @@ public class ApiAccessObject {
      * @return The travel price from start to end
      * @throws InvalidLocationException One of the inputted locations has invalid
      */
-    public float getPrice(String start, String end) throws InvalidLocationException {
+    public float getPrice(String start, String end) throws InvalidLocationException, ApiAccessException {
         List<String> fields = new ArrayList<>();
         fields.add("eta");
         fields.add("distance");
@@ -70,7 +71,7 @@ public class ApiAccessObject {
      * @return A URL for an image that displays a route from start to end
      * @throws InvalidLocationException One of the inputted locations has invalid
      */
-    public String getTrafficMap(String start, String end) throws InvalidLocationException {
+    public String getTrafficMap(String start, String end) throws InvalidLocationException, ApiAccessException {
         OkHttpClient client = new OkHttpClient();
 
         HttpUrl httpUrl = new HttpUrl.Builder()
@@ -97,7 +98,7 @@ public class ApiAccessObject {
                 throw new InvalidLocationException("Invalid location");
             }
         } catch (IOException | JSONException e) {
-            throw new InvalidLocationException("Invalid location");
+            throw new ApiAccessException();
         }
     }
 
@@ -110,7 +111,7 @@ public class ApiAccessObject {
      * @return Map from strings that denote fields, to floats, that denote information corresponding to said field
      * @throws InvalidLocationException Either the start or end location was invalid
      */
-    private Map<String, Float> requestRoutingData(String start, String end, List<String> fields) throws InvalidLocationException {
+    private Map<String, Float> requestRoutingData(String start, String end, List<String> fields) throws InvalidLocationException, ApiAccessException {
         OkHttpClient client = new OkHttpClient();
 
         HttpUrl httpUrl = new HttpUrl.Builder()
@@ -144,7 +145,7 @@ public class ApiAccessObject {
                 throw new InvalidLocationException("Invalid location");
             }
         } catch (IOException | JSONException e) {
-            throw new InvalidLocationException("Invalid location");
+            throw new ApiAccessException();
         }
     }
 }

--- a/src/main/java/data_access/ApiAccessObject.java
+++ b/src/main/java/data_access/ApiAccessObject.java
@@ -1,0 +1,130 @@
+package data_access;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import use_case.CreateRequest.InvalidLocationException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ApiAccessObject {
+    private String apiKey;
+
+    public ApiAccessObject(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    /**
+     * Get the distance from a start to an end location
+     *
+     * @param start The start location
+     * @param end The end location
+     * @return The distance from start to end
+     * @throws InvalidLocationException One of the inputted locations has invalid
+     */
+    public float getDistance(String start, String end) throws InvalidLocationException {
+        return requestDistanceAndEta(start, end).get("distance");
+    }
+
+    /**
+     * Get the ETA from a start to an end location
+     *
+     * @param start The start location
+     * @param end The end location
+     * @return The ETA from start to end
+     * @throws InvalidLocationException One of the inputted locations has invalid
+     */
+    public float getEta(String start, String end) throws InvalidLocationException {
+        return requestDistanceAndEta(start, end).get("eta");
+    }
+
+    /**
+     * Get the price from a start to an end location
+     *
+     * @param start The start location
+     * @param end The end location
+     * @return The travel price from start to end
+     * @throws InvalidLocationException One of the inputted locations has invalid
+     */
+    public float getPrice(String start, String end) throws InvalidLocationException {
+        return requestDistanceAndEta(start, end).get("distance") * 0.1f;
+    }
+
+    /**
+     * Return an image URL that displays a route from the start to the end location
+     *
+     * @param start The start location
+     * @param end The end location
+     * @return A URL for an image that displays a route from start to end
+     * @throws InvalidLocationException One of the inputted locations has invalid
+     */
+    public String getTrafficMap(String start, String end) throws InvalidLocationException {
+        OkHttpClient client = new OkHttpClient();
+
+        HttpUrl httpUrl = new HttpUrl.Builder()
+                .scheme("https")
+                .host("www.mapquestapi.com")
+                .addPathSegment("staticmap")
+                .addPathSegment("v5")
+                .addPathSegment("map")
+                .addQueryParameter("key", this.apiKey)
+                .addQueryParameter("start", start)
+                .addQueryParameter("end", end)
+                .build();
+
+        Request request = new Request.Builder().url(httpUrl).build();
+
+        try {
+            // execute and print API response
+            Response response = client.newCall(request).execute();
+            System.out.println("Response : " + response);
+            if (response.code() == 200) {
+                JSONObject responseBody = new JSONObject(response.body().string());
+                return responseBody.getString("url");
+            } else {
+                throw new InvalidLocationException("Invalid location");
+            }
+        } catch (IOException | JSONException e) {
+            throw new InvalidLocationException("Invalid location");
+        }
+    }
+
+    private Map<String, Float> requestDistanceAndEta(String start, String end) throws InvalidLocationException {
+        OkHttpClient client = new OkHttpClient();
+
+        HttpUrl httpUrl = new HttpUrl.Builder()
+                .scheme("https")
+                .host("www.mapquestapi.com")
+                .addPathSegment("directions")
+                .addPathSegment("v2")
+                .addPathSegment("route")
+                .addQueryParameter("key", this.apiKey)
+                .addQueryParameter("from", start)
+                .addQueryParameter("to", end)
+                .build();
+
+        Request request = new Request.Builder().url(httpUrl).build();
+
+        try {
+            // execute and print API response
+            Response response = client.newCall(request).execute();
+            System.out.println("Response : " + response);
+            if (response.code() == 200) {
+                JSONObject responseBody = new JSONObject(response.body().string());
+
+                JSONObject route = responseBody.getJSONObject("route");
+                Map<String, Float> distanceEtaMap = new HashMap<>();
+                distanceEtaMap.put("distance", route.getFloat("distance") / 10);
+                distanceEtaMap.put("eta", (float) route.getInt("time"));
+                return distanceEtaMap;
+            } else {
+                throw new InvalidLocationException("Invalid location");
+            }
+        } catch (IOException | JSONException e) {
+            throw new InvalidLocationException("Invalid location");
+        }
+    }
+
+}

--- a/src/main/java/data_access/ApiAccessObject.java
+++ b/src/main/java/data_access/ApiAccessObject.java
@@ -91,6 +91,15 @@ public class ApiAccessObject {
         }
     }
 
+    /**
+     * Helper function that calls the api and requests routing information. Returns information relevant to
+     * the public methods. This function ought ot be modified if more public methods are added.
+     *
+     * @param start The start location
+     * @param end The end location
+     * @return Map from strings that denote fields, to floats, that denote information corresponding to said field
+     * @throws InvalidLocationException Either the start or end location was invalid
+     */
     private Map<String, Float> requestDistanceAndEta(String start, String end) throws InvalidLocationException {
         OkHttpClient client = new OkHttpClient();
 

--- a/src/main/java/use_case/CreateRequest/ApiAccessException.java
+++ b/src/main/java/use_case/CreateRequest/ApiAccessException.java
@@ -1,0 +1,14 @@
+package use_case.CreateRequest;
+
+/**
+ * Exception to be thrown whenever there is an issue accessing the API.
+ */
+public class ApiAccessException extends Exception {
+
+    /**
+     * Create a ApiAccessException.
+     */
+    public ApiAccessException() {
+        super("There was a problem accessing the routing API");
+    }
+}

--- a/src/main/java/use_case/CreateRequest/CreateRequestApiAccessInterface.java
+++ b/src/main/java/use_case/CreateRequest/CreateRequestApiAccessInterface.java
@@ -11,7 +11,7 @@ public interface CreateRequestApiAccessInterface {
      * @param endLoc Address/name representing the end location.
      * @return The distance by car from startLoc to endLoc by car.
      */
-    public float getDistance(String startLoc, String endLoc) throws InvalidLocationException;
+    public float getDistance(String startLoc, String endLoc) throws InvalidLocationException, ApiAccessException;
 
     /**
      * Return the estimated time or arrival from startLoc to endLoc by car.
@@ -20,7 +20,7 @@ public interface CreateRequestApiAccessInterface {
      * @param endLoc Address/name representing the end location.
      * @return The estimated time or arrival from startLoc to endLoc by car.
      */
-    public float getEta(String startLoc, String endLoc) throws InvalidLocationException;
+    public float getEta(String startLoc, String endLoc) throws InvalidLocationException, ApiAccessException;
 
     /**
      * Return the price of a car ride from startLoc to endLoc by car.
@@ -29,5 +29,5 @@ public interface CreateRequestApiAccessInterface {
      * @param endLoc Address/name representing the end location.
      * @return The estimated price of a car ride from startLoc to endLoc by car.
      */
-    public float getPrice(String startLoc, String endLoc) throws InvalidLocationException;
+    public float getPrice(String startLoc, String endLoc) throws InvalidLocationException, ApiAccessException;
 }

--- a/src/main/java/use_case/CreateRequest/CreateRequestApiAccessInterface.java
+++ b/src/main/java/use_case/CreateRequest/CreateRequestApiAccessInterface.java
@@ -5,7 +5,7 @@ package use_case.CreateRequest;
  */
 public interface CreateRequestApiAccessInterface {
     /**
-     * Return the distance by car from startLoc to endLoc by car.
+     * Return the distance by car from startLoc to endLoc by car in km.
      *
      * @param startLoc Address/name representing the starting location.
      * @param endLoc Address/name representing the end location.
@@ -14,7 +14,7 @@ public interface CreateRequestApiAccessInterface {
     public float getDistance(String startLoc, String endLoc) throws InvalidLocationException, ApiAccessException;
 
     /**
-     * Return the estimated time or arrival from startLoc to endLoc by car.
+     * Return the estimated time or arrival from startLoc to endLoc by car in minutes.
      *
      * @param startLoc Address/name representing the starting location.
      * @param endLoc Address/name representing the end location.
@@ -23,7 +23,7 @@ public interface CreateRequestApiAccessInterface {
     public float getEta(String startLoc, String endLoc) throws InvalidLocationException, ApiAccessException;
 
     /**
-     * Return the price of a car ride from startLoc to endLoc by car.
+     * Return the price of a car ride from startLoc to endLoc by car in minutes.
      *
      * @param startLoc Address/name representing the starting location.
      * @param endLoc Address/name representing the end location.

--- a/src/main/java/use_case/CreateRequest/CreateRequestInteractor.java
+++ b/src/main/java/use_case/CreateRequest/CreateRequestInteractor.java
@@ -85,6 +85,9 @@ public class CreateRequestInteractor implements CreateRequestInputBoundary {
         } catch (InvalidLocationException e) {
             this.completeRequestPresenter.prepareFailView("Invalid location!");
             return;
+        } catch (ApiAccessException e) {
+            this.completeRequestPresenter.prepareFailView("There was a problem accessing the API, please try again later!");
+            return;
         }
 
         servicePrice = requestedService.getPrice();
@@ -118,7 +121,7 @@ public class CreateRequestInteractor implements CreateRequestInputBoundary {
      * @param destination The destination to which the doctor is traveling.
      * @return A Map from available doctors to their ETA to destination.
      */
-    private Map<Doctor, Float> createDoctorEtaMap(String destination) throws InvalidLocationException {
+    private Map<Doctor, Float> createDoctorEtaMap(String destination) throws InvalidLocationException, ApiAccessException {
         List<Doctor> availableDoctors = this.doctorDataAccessObject.getAvailableDoctors();
         Map<Doctor, Float> doctorEtaMap = new HashMap<>();
 

--- a/src/test/java/data_access/ApiAccessObjectTest.java
+++ b/src/test/java/data_access/ApiAccessObjectTest.java
@@ -8,41 +8,58 @@ import use_case.CreateRequest.InvalidLocationException;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ApiAccessObjectTest {
-    private ApiAccessObject apiAccessObject = new ApiAccessObject("");
+    private final String apiKey = "";
+    private ApiAccessObject apiAccessObject = new ApiAccessObject(apiKey);
 
     @Test
     void testGetEta() {
-        try {
-            assertEquals(60, apiAccessObject.getEta("University of Toronto", "York University"), 60);
-        } catch (InvalidLocationException | ApiAccessException e) {
-            fail("Successful API call expected");
+        if (this.apiKey.equals("")) {
+            return;
+        } else {
+            try {
+                assertEquals(60, apiAccessObject.getEta("University of Toronto", "York University"), 60);
+            } catch (InvalidLocationException | ApiAccessException e) {
+                fail("Successful API call expected");
+            }
         }
     }
 
     @Test
     void testGetDistance() {
-        try {
-            assertEquals(87, apiAccessObject.getDistance("University of Toronto", "York University"), 1);
-        } catch (InvalidLocationException | ApiAccessException e) {
-            fail("Successful API call expected");
+        if (this.apiKey.equals("")) {
+            return;
+        } else {
+            try {
+                assertEquals(87, apiAccessObject.getDistance("University of Toronto", "York University"), 1);
+            } catch (InvalidLocationException | ApiAccessException e) {
+                fail("Successful API call expected");
+            }
         }
     }
 
     @Test
     void testGetPrice() {
-        try {
-            assertEquals(60, apiAccessObject.getPrice("University of Toronto", "York University"), 60);
-        } catch (InvalidLocationException | ApiAccessException e) {
-            fail("Successful API call expected");
+        if (this.apiKey.equals("")) {
+            return;
+        } else {
+            try {
+                assertEquals(60, apiAccessObject.getPrice("University of Toronto", "York University"), 60);
+            } catch (InvalidLocationException | ApiAccessException e) {
+                fail("Successful API call expected");
+            }
         }
     }
 
     @Test
     void testGetTrafficMap() {
-        try {
-            assertNotEquals("", apiAccessObject.getTrafficMap("University of Toronto", "York University"));
-        } catch (InvalidLocationException | ApiAccessException e) {
-            fail("Successful API call expected");
+        if (this.apiKey.equals("")) {
+            return;
+        } else {
+            try {
+                assertNotEquals("", apiAccessObject.getTrafficMap("University of Toronto", "York University"));
+            } catch (InvalidLocationException | ApiAccessException e) {
+                fail("Successful API call expected");
+            }
         }
     }
 }

--- a/src/test/java/data_access/ApiAccessObjectTest.java
+++ b/src/test/java/data_access/ApiAccessObjectTest.java
@@ -8,7 +8,7 @@ import use_case.CreateRequest.InvalidLocationException;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ApiAccessObjectTest {
-    private ApiAccessObject apiAccessObject = new ApiAccessObject("pnI7fJLjm5NikjPKjrFHxFb1oW7rwmWx");
+    private ApiAccessObject apiAccessObject = new ApiAccessObject("");
 
     @Test
     void testGetEta() {

--- a/src/test/java/data_access/ApiAccessObjectTest.java
+++ b/src/test/java/data_access/ApiAccessObjectTest.java
@@ -1,0 +1,48 @@
+package data_access;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import use_case.CreateRequest.ApiAccessException;
+import use_case.CreateRequest.InvalidLocationException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApiAccessObjectTest {
+    private ApiAccessObject apiAccessObject = new ApiAccessObject("pnI7fJLjm5NikjPKjrFHxFb1oW7rwmWx");
+
+    @Test
+    void testGetEta() {
+        try {
+            assertEquals(60, apiAccessObject.getEta("University of Toronto", "York University"), 60);
+        } catch (InvalidLocationException | ApiAccessException e) {
+            fail("Successful API call expected");
+        }
+    }
+
+    @Test
+    void testGetDistance() {
+        try {
+            assertEquals(87, apiAccessObject.getDistance("University of Toronto", "York University"), 1);
+        } catch (InvalidLocationException | ApiAccessException e) {
+            fail("Successful API call expected");
+        }
+    }
+
+    @Test
+    void testGetPrice() {
+        try {
+            assertEquals(60, apiAccessObject.getPrice("University of Toronto", "York University"), 60);
+        } catch (InvalidLocationException | ApiAccessException e) {
+            fail("Successful API call expected");
+        }
+    }
+
+    @Test
+    void testGetTrafficMap() {
+        try {
+            assertNotEquals("", apiAccessObject.getTrafficMap("University of Toronto", "York University"));
+        } catch (InvalidLocationException | ApiAccessException e) {
+            fail("Successful API call expected");
+        }
+    }
+}

--- a/src/test/java/data_access/ApiAccessObjectTest.java
+++ b/src/test/java/data_access/ApiAccessObjectTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ApiAccessObjectTest {
     private final String apiKey = "";
-    private ApiAccessObject apiAccessObject = new ApiAccessObject(apiKey);
+    private final ApiAccessObject apiAccessObject = new ApiAccessObject(apiKey);
 
     @Test
     void testGetEta() {
@@ -25,15 +25,35 @@ class ApiAccessObjectTest {
     }
 
     @Test
+    void testGetEtaFail() {
+        if (this.apiKey.equals("")) {
+            return;
+        } else {
+            assertThrows(InvalidLocationException.class, () -> {apiAccessObject.getEta("NSIUFDsifuy9gyfq8", "York University");});
+            assertThrows(ApiAccessException.class, () -> {(new ApiAccessObject("")).getEta("1", " 1");});
+        }
+    }
+
+    @Test
     void testGetDistance() {
         if (this.apiKey.equals("")) {
             return;
         } else {
             try {
-                assertEquals(87, apiAccessObject.getDistance("University of Toronto", "York University"), 1);
+                assertEquals(8.7, apiAccessObject.getDistance("University of Toronto", "York University"), 1);
             } catch (InvalidLocationException | ApiAccessException e) {
                 fail("Successful API call expected");
             }
+        }
+    }
+
+    @Test
+    void testGetDistanceFail() {
+        if (this.apiKey.equals("")) {
+            return;
+        } else {
+            assertThrows(InvalidLocationException.class, () -> {apiAccessObject.getDistance("NSIUFDsifuy9gyfq8", "York University");});
+            assertThrows(ApiAccessException.class, () -> {(new ApiAccessObject("")).getDistance("1", " 1");});
         }
     }
 
@@ -51,6 +71,16 @@ class ApiAccessObjectTest {
     }
 
     @Test
+    void testGetPriceFail() {
+        if (this.apiKey.equals("")) {
+            return;
+        } else {
+            assertThrows(InvalidLocationException.class, () -> {apiAccessObject.getPrice("NSIUFDsifuy9gyfq8", "York University");});
+            assertThrows(ApiAccessException.class, () -> {(new ApiAccessObject("")).getPrice("1", " 1");});
+        }
+    }
+
+    @Test
     void testGetTrafficMap() {
         if (this.apiKey.equals("")) {
             return;
@@ -60,6 +90,15 @@ class ApiAccessObjectTest {
             } catch (InvalidLocationException | ApiAccessException e) {
                 fail("Successful API call expected");
             }
+        }
+    }
+
+    @Test
+    void testGetTrafficMapFail() {
+        if (this.apiKey.equals("")) {
+            return;
+        } else {
+            assertThrows(ApiAccessException.class, () -> {(new ApiAccessObject("")).getTrafficMap("1", " 1");});
         }
     }
 }


### PR DESCRIPTION
TLDR; Implemented functionality for the APIAccessObject.

# Requirements : 

The user should be able to request various details about the route from one location to another. In particular, they should be able to get the distance, estimated time or arrival, price of travel, and a map of a plausible route between two locations. You should be able to pass strings denoting addresses or well known landmarks when requesting such data.

The API key for MapQuest ought to be provided by the user, as it isn't safe to hard code the API key within the APIAccessObject.

# Implementation Details :

The object has four public facing functions. `getDistance()`, `getPrice()`, `getEta()` call upon the same MapQuest endpoint. As a result, they rely on a private helper, `requestRoutingData()`, that extracts `float` fields from a routing request. Passing a file of desired fields to the private helper is an instance of open closed, as it prevents the need to modify the private helper.

`getTrafficMap()` returns a URL to an image. It uses a unique endpoint, so the HTTP request isn't factored into a helper.

Each public method can throw one of two exceptions, `ApiAccessException` indicates a response code other than 200, and `InvalidLocationException` indicates one of the parameters wasn't read by the API as a valid location. This should be handled by the interactor by preparing the fail view.

# Testing :

Very minimal testing has been done, as the primary logic is handled by the API. However, each public method is tested for success, and 2 types of failure. 

Note that if you try to run the tests yourself, you'll have to modify the `apiKey` instance variable within the test class. As of now, the tests will still pass, but won't check for correctness. I've run these tests using my own key and they all pass.

More comprehensive testing be be accomplished via integration testing with the create request use case interactor.

# Notes :

Added `okhttp3` and `json` dependencies.